### PR TITLE
add hmr support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': [0],
     '@typescript-eslint/no-explicit-any': [0],
     '@typescript-eslint/no-non-null-assertion': [0],
+    'operator-linebreak': [0],
   },
   settings: {
     'import/resolver': {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/jsx-explorer/src/index.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/babel-plugin-jsx/package.json
+++ b/packages/babel-plugin-jsx/package.json
@@ -23,19 +23,24 @@
     "dist"
   ],
   "dependencies": {
+    "@babel/generator": "^7.12.11",
     "@babel/helper-module-imports": "^7.0.0",
+    "@babel/parser": "^7.12.11",
     "@babel/plugin-syntax-jsx": "^7.0.0",
     "@babel/template": "^7.0.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
     "@vue/babel-helper-vue-transform-on": "^1.0.0",
     "camelcase": "^6.0.0",
+    "hash": "^0.2.1",
+    "hash-sum": "^2.0.0",
     "html-tags": "^3.1.0",
     "svg-tags": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@types/hash-sum": "^1.0.0",
     "@types/jest": "^26.0.7",
     "@types/svg-tags": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",

--- a/packages/babel-plugin-jsx/src/inject-hmr.ts
+++ b/packages/babel-plugin-jsx/src/inject-hmr.ts
@@ -1,0 +1,137 @@
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+import generate from '@babel/generator';
+import { parse } from '@babel/parser';
+import hash from 'hash-sum';
+
+import { State } from '.';
+
+export default function injectHmr(path: NodePath<t.Program>, state: State) {
+  if (!state.get('HOT_MODULE_ID')) return;
+
+  const id = state.get('HOT_MODULE_ID');
+  const source = generate(path.node).code;
+
+  // const nodes = path.node.body;
+
+  /**
+   * @type {{ name: string, hash: string }[]}
+   */
+  const declaredComponents: {
+    local: string;
+    exported: string;
+    id: string;
+    hash: string;
+  }[] = [];
+
+  path.get('body').forEach((p) => {
+    const { node } = p;
+    if (node.type === 'VariableDeclaration') {
+      // ;(node as t.Declaration | t.ExportDeclaration).
+      const names = parseComponentDecls(node, source);
+      if (names.length) {
+        declaredComponents.push(
+          ...names.map(({ name, hash: _hash }) => ({
+            local: name,
+            exported: name,
+            id: hash(id + name),
+            hash: _hash,
+          })),
+        );
+      }
+    }
+
+    if (node.type === 'ExportNamedDeclaration') {
+      if (node.declaration && node.declaration.type === 'VariableDeclaration') {
+        declaredComponents.push(
+          ...parseComponentDecls(node.declaration, source).map(
+            ({ name, hash: _hash }) => ({
+              local: name,
+              exported: name,
+              id: hash(id + name),
+              hash: _hash,
+            }),
+          ),
+        );
+      }
+    }
+
+    if (
+      node.type === 'ExportDefaultDeclaration' &&
+      isDefineComponentCall(node.declaration)
+    ) {
+      declaredComponents.push({
+        local: '__default__',
+        exported: 'default',
+        id: hash(`${id} default`),
+        hash: hash(
+          source.slice(node.declaration.start!, node.declaration.end!),
+        ),
+      });
+
+      p.replaceWith(
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier('__default__'),
+            node.declaration as t.CallExpression,
+          ),
+        ]),
+      );
+
+      p.insertAfter(t.exportDefaultDeclaration(t.identifier('__default__')));
+    }
+  });
+
+  let code = '';
+  if (declaredComponents.length) {
+    let callbackCode = '';
+    // eslint-disable-next-line
+    for (const { local, id, hash } of declaredComponents) {
+      code +=
+        `\n${local}.__hmrId = "${id}"` +
+        `\n${local}.__hmrHash = "${hash}"` +
+        `\n__VUE_HMR_RUNTIME__.createRecord("${id}", ${local})`;
+      callbackCode +=
+        `\n  if (${local}.__hmrHash !== $VueHMRHashMap$["${id}"]) {` +
+        `\n__VUE_HMR_RUNTIME__.reload("${id}", ${local})` +
+        `\n$VueHMRHashMap$["${id}"] = "${hash}"` +
+        '}';
+    }
+
+    code += `\nif($isVueHMRAcceptable(module)){
+      module.hot.accept()
+      ${callbackCode}
+    }`;
+  }
+
+  path.node.body.push(...parse(code, { sourceType: 'module' }).program.body);
+}
+
+/**
+ * @param {import('@babel/core').types.VariableDeclaration} node
+ * @param {string} source
+ */
+function parseComponentDecls(node: t.VariableDeclaration, source: string) {
+  const names = [];
+  // eslint-disable-next-line
+  for (const decl of node.declarations as any) {
+    if (decl.id.type === 'Identifier' && isDefineComponentCall(decl.init)) {
+      names.push({
+        name: decl.id.name,
+        hash: hash(source.slice(decl.init.start, decl.init.end)),
+      });
+    }
+  }
+  return names;
+}
+
+/**
+ * @param {import('@babel/core').types.Node} node
+ */
+function isDefineComponentCall(node: t.Node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'defineComponent'
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.npm.taobao.org/@babel/generator/download/@babel/generator-7.12.11.tgz?cache=0&sync_timestamp=1608076904393&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fgenerator%2Fdownload%2F%40babel%2Fgenerator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
+  integrity sha1-mKffe4w1jJo3qweiQFaFMBaro68=
+  dependencies:
+    "@babel/types" "^7.12.11"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz#54ab9b000e60a93644ce17b3f37d313aaf1d115d"
@@ -250,6 +259,11 @@
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.10.tgz#824600d59e96aea26a5a2af5a9d812af05c3ae81"
   integrity sha512-PJdRPwyoOqFAWfLytxrWwGrAxghCgh/yTNCYciOz8QgjflA7aZhECPZAa2VUedKg2+QMWkI0L9lynh2SNmNEgA==
+
+"@babel/parser@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.npm.taobao.org/@babel/parser/download/@babel/parser-7.12.11.tgz?cache=0&sync_timestamp=1608076906959&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fparser%2Fdownload%2F%40babel%2Fparser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
+  integrity sha1-nONZW810vFxGaQXobFNbiyUBHnk=
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1":
   version "7.12.1"
@@ -830,6 +844,15 @@
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.11.tgz#a86e4d71e30a9b6ee102590446c98662589283ce"
   integrity sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.11":
+  version "7.12.12"
+  resolved "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.12.12.tgz?cache=0&sync_timestamp=1608730523321&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftypes%2Fdownload%2F%40babel%2Ftypes-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  integrity sha1-Rgim7DE6u9h6+lUATTc60EqWwpk=
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
@@ -2025,6 +2048,11 @@
   integrity sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==
   dependencies:
     "@types/node" "*"
+
+"@types/hash-sum@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npm.taobao.org/@types/hash-sum/download/@types/hash-sum-1.0.0.tgz?cache=0&sync_timestamp=1605055270093&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhash-sum%2Fdownload%2F%40types%2Fhash-sum-1.0.0.tgz#838f4e8627887d42b162d05f3d96ca636c2bc504"
+  integrity sha1-g49OhieIfUKxYtBfPZbKY2wrxQQ=
 
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
@@ -5544,6 +5572,11 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
+hash-sum@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npm.taobao.org/hash-sum/download/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
+  integrity sha1-gdAbtd6OpKIUrV1urRtSNGCwtFo=
+
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
@@ -5551,6 +5584,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hash@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npm.taobao.org/hash/download/hash-0.2.1.tgz#a719d789397c5637f02043c0c180f431fdf9a6ec"
+  integrity sha1-pxnXiTl8VjfwIEPAwYD0Mf35puw=
 
 he@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This pr try to define how hmr will work in jsx of Vue3. I learned a lot from react fast refresh and vite jsx plugin.

Main feature:

- Only reload component that changed
- Support multi component in one file
- Bundler independent(not sure now if other platform other then webpack will work)
- If module not only export component, reload all

We still need a webpack plugin or loader to provide some info.

`$HotMoudleId$` mostly file relative path that is unique in one project

`$isVueHMRAcceptable` a function test if this module export only components, return true if it does.

`var $VueHMRHashMap$ = (window.$VueHMRHashMap$ = window.$VueHMRHashMap$ || {});` it store every component and it's code hash, make it possible to diff if one component updated when hmr.

@Amour1688 please review the code.